### PR TITLE
#23-サイドメニュー下の2020 Tokyo Metropolitan Governmentを山形版に直す

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -107,7 +107,7 @@
           </a>
           {{ $t('の下に提供されています。') }}
           <br />
-          2020 Tokyo Metropolitan Government
+          本サイトは、山形県内外の有志の手により運用されています
         </small>
       </footer>
     </div>


### PR DESCRIPTION

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #23 

## 📝 関連する issue / Related Issues
- #23 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- サイドメニュー下の2020 Tokyo Metropolitan Governmentを山形版に直す
(変更内容は新潟県を参考にさせていただいた)https://stopcovid19-niigata-unofficial.netlify.com/

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/62947068/78566119-bd34d480-7859-11ea-91f3-8f2076af0ae4.png)
