### PR TITLE
Data.jsonの更新に合わせてmapとnetworkのページの日付も更新する

### DIFF
--- a/pages/map.vue
+++ b/pages/map.vue
@@ -43,6 +43,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { MetaInfo } from 'vue-meta'
+import dayjs from 'dayjs'
 import StaticCard from '@/components/StaticCard.vue'
 import MapGeojson from '@/static/yamagata_map.geojson.json'
 import Data from '@/data/data.json'
@@ -66,15 +67,23 @@ export default Vue.extend({
       },
       geojson: MapGeojson,
       geojsonOptions: {},
-      lastUpdate: MapCityName.lastUpdate,
+      lastUpdate: '',
       remainderData: []
     }
     return dataObject
   },
   mounted() {
+    this.lastUpdate = this.getLastUpdate()
     this.setInfectionPersonCountData()
   },
   methods: {
+    getLastUpdate() {
+      const dataDate = Data.patients.date
+      const mapCityNameDate = MapCityName.lastUpdate
+      return dayjs(dataDate).isAfter(dayjs(mapCityNameDate))
+        ? dataDate
+        : mapCityNameDate
+    },
     getInfectionPersonCount() {
       const infectionPersonCount: any = {}
       Data.patients.data.forEach((infectionPerson: any) => {

--- a/pages/network.vue
+++ b/pages/network.vue
@@ -23,6 +23,7 @@
 import Vue from 'vue'
 import { MetaInfo } from 'vue-meta'
 import VueCytoscape from 'vue-cytoscape'
+import dayjs from 'dayjs'
 import StaticCard from '@/components/StaticCard.vue'
 import VirusNetwork from '@/data/virusNetwork.json'
 import Data from '@/data/data.json'
@@ -82,11 +83,12 @@ export default Vue.extend({
         nodeDimensionsIncludeLabels: true
       },
       elements: [],
-      lastUpdate: VirusNetwork.lastUpdate
+      lastUpdate: ''
     }
     return dataObject
   },
   mounted() {
+    this.lastUpdate = this.getLastUpdate()
     this.elements = this.getElementsData()
     this.$nextTick(() => {
       const vueCy: any = this.$refs.cy
@@ -99,6 +101,13 @@ export default Vue.extend({
   methods: {
     preConfig(cytoscape: any) {
       cytoscape.use(coseBilkent)
+    },
+    getLastUpdate() {
+      const dataDate = Data.patients.date
+      const virusNetworkDate = VirusNetwork.lastUpdate
+      return dayjs(dataDate).isAfter(dayjs(virusNetworkDate))
+        ? dataDate
+        : virusNetworkDate
     },
     getElementsData() {
       const virusNetwork: any = VirusNetwork


### PR DESCRIPTION
Data.jsonの更新に合わせてmapとnetworkのページの日付も更新する
（mapとnetworkのjsonデータのほうが新しい場合はそちらの日付が優先）